### PR TITLE
Set SocketID for Items when viewing an item

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    catalogapi (0.1.0rc1)
+    catalogapi (0.1.0rc3)
       http (~> 4.0)
 
 GEM

--- a/lib/catalogapi/item.rb
+++ b/lib/catalogapi/item.rb
@@ -57,7 +57,7 @@ module CatalogAPI
       request = CatalogAPI.request.new(:view_item)
                           .get(socket_id: socket_id, catalog_item_id: catalog_item_id)
       fields = request.json.dig(:view_item_response, :view_item_result, :item)
-      request.data = self.class.new(fields)
+      request.data = self.class.new(fields.merge(socket_id: socket_id))
       request
     end
   end

--- a/lib/catalogapi/version.rb
+++ b/lib/catalogapi/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CatalogAPI
-  VERSION = '0.1.0rc2'
+  VERSION = '0.1.0rc3'
 end

--- a/spec/catalogapi/item_spec.rb
+++ b/spec/catalogapi/item_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe CatalogAPI::Item do
         .to_return(status: 200, body: body.to_json, headers: {})
       request = item.view
       expect(request.data.description).to_not eq nil
+      expect(request.data.socket_id).to_not eq nil
     end
 
     it 'requires catalog_item_id' do


### PR DESCRIPTION
The Order#place requires the socket id to be within the Item. When viewing an item you have access to the socket id however it is not returned in the response. This PR fixes that issue